### PR TITLE
fix: avoid ios keyboard to push view up

### DIFF
--- a/src/pages/dashboard/dashboard.style.tsx
+++ b/src/pages/dashboard/dashboard.style.tsx
@@ -29,8 +29,10 @@ const getSidebarAnimation = (menuOpen: boolean): string => `
 `;
 
 export const DashboardContainer = Styled.div`
-  height: 100vh;
+  bottom: 0;
   overflow: hidden;
+  position: absolute;
+  top: 0;
   width: 100%;
 
   background-color: ${COLOR_BLACK};
@@ -114,7 +116,6 @@ export const MobileMenuButtonContainer = Styled.div`
 
 export const BodyContainer = Styled.div<{ menuOpen: boolean }>`
   bottom: 0;
-  height: 100vh;
   overflow: hidden;
   position: absolute;
   top: 0;

--- a/src/styles/body.style.css
+++ b/src/styles/body.style.css
@@ -1,5 +1,6 @@
 /* Default styles for body */
 
+html,
 body {
   overflow: hidden;
 }


### PR DESCRIPTION
## PR Overview

> **Project Card: [42448950](https://github.com/users/Zjarr/projects/1#card-42448950)**

Fix an issue on iOS that pushed the view up when the keyboard was displayed

## PR Checklist
- [x] All dependencies are updated.
- [x] Atomic commits.
- [x] Rebase master.
- [x] Linter shows no warnings or errors.
- [x] Build is successful.
- [x] Final review by author.
